### PR TITLE
#00 @yrachid: Remove pacote BucketCalculator

### DIFF
--- a/backend/src/main/java/com/thoughtworks/aceleradora/service/bucketcalculator/BucketCalculator.java
+++ b/backend/src/main/java/com/thoughtworks/aceleradora/service/bucketcalculator/BucketCalculator.java
@@ -1,10 +1,12 @@
 package com.thoughtworks.aceleradora.service.bucketcalculator;
 
 import java.math.BigDecimal;
-import static com.thoughtworks.aceleradora.service.bucketcalculator.BucketZones.*;
-import static com.thoughtworks.aceleradora.service.bucketcalculator.Materials.*;
 
-
+import static com.thoughtworks.aceleradora.service.bucketcalculator.BucketZones.DOWNTOWN;
+import static com.thoughtworks.aceleradora.service.bucketcalculator.BucketZones.SOUTH_ZONE;
+import static com.thoughtworks.aceleradora.service.bucketcalculator.Materials.MIXED;
+import static com.thoughtworks.aceleradora.service.bucketcalculator.Materials.PLASTER;
+import static com.thoughtworks.aceleradora.service.bucketcalculator.Materials.RUBBLE;
 
 public class BucketCalculator {
     public static void main(String[] args) {
@@ -15,12 +17,16 @@ public class BucketCalculator {
     }
 
     public BigDecimal calculateBucketEstimate(BucketEstimateParameters params) {
-        if (params.getBucketZones() == DOWNTOWN || params.getBucketZones() == SOUTHZONE || params.getMaterials() == MIXED) {
-            return new BigDecimal("350").multiply(new BigDecimal(Integer.toString(params.getBucketAmount())));
+        BigDecimal bucketAmount = new BigDecimal(params.getBucketAmount());
+
+        if (params.getBucketZones() == DOWNTOWN || params.getBucketZones() == SOUTH_ZONE || params.getMaterials() == MIXED) {
+            return new BigDecimal("350").multiply(bucketAmount);
         }
-        if(params.getMaterials() == RUBBLE){
-            return new BigDecimal("250").multiply(new BigDecimal(Integer.toString(params.getBucketAmount())));
+
+        if (params.getMaterials() == RUBBLE) {
+            return new BigDecimal("250").multiply(bucketAmount);
         }
-        return new BigDecimal("300").multiply(new BigDecimal(Integer.toString(params.getBucketAmount())));
+
+        return new BigDecimal("300").multiply(bucketAmount);
     }
 }

--- a/backend/src/main/java/com/thoughtworks/aceleradora/service/bucketcalculator/BucketZones.java
+++ b/backend/src/main/java/com/thoughtworks/aceleradora/service/bucketcalculator/BucketZones.java
@@ -2,6 +2,6 @@ package com.thoughtworks.aceleradora.service.bucketcalculator;
 
 public enum BucketZones {
     DOWNTOWN,
-    SOUTHZONE,
-    OUTHERZONES
+    SOUTH_ZONE,
+    OTHER_ZONES
 }


### PR DESCRIPTION
Este pacote conflita com a existência do pacote `bucketcalculator`. Em sistemas operacionais com sistemas de arquivos que não são case sensitive (Windows e Mac), isso ocasiona problemas, dado que o sistema não consegue distinguir os dois pacotes. Outros pontos importantes:
- O pacote `BucketCalculator` possuia somente uma classe, tornando-se redundante
- O pacote `BucketCalculator` não segue a convenção de nomenclatura de pacotes Java