### PR TITLE
@Elliens @Jhuan0999: Ajusta css do faq para resolver o problema de op…

### DIFF
--- a/frontend/src/components/FAQ/FaqStyle.css
+++ b/frontend/src/components/FAQ/FaqStyle.css
@@ -76,7 +76,7 @@
    color: #636363 !important;
    font-weight: 200;
    font-size: 16px;
-   opacity: 100%;
+   opacity: 100% !important;
  }
 
 .duvidas {


### PR DESCRIPTION
Foi adicionado !important na estilização de opacidade do body-faq pois quando o projeto é enviado ao ambiente do Heroku a opacidade que estava antes 100% fica 1%. E por não poder testar localmente, estou abrindo o PR para poder ver se vai resolver o problema no ambiente de homologação.

