### PR TITLE
#146/@liasantos @nicolasgbdas: acrescenta endpoint no botão mobile

### DIFF
--- a/frontend/src/components/ModalConfirmation/index.js
+++ b/frontend/src/components/ModalConfirmation/index.js
@@ -59,7 +59,7 @@ function ModalConfirmation({ display, onClick, estimateValue, material }) {
       <button className="btn-approve" name="finishOrder" onClick={onClick}>
         Solicitar Agendamento
       </button>
-      <button className="btn-approve-mobile">
+      <button className="btn-approve-mobile" name="finishOrder" onClick={onClick}>
         Solicitar<FontAwesomeIcon className= "fontawesome" icon={faCheckCircle} />
       </button>
     </div>


### PR DESCRIPTION
Botão mobile "Solicitar" da segunda modal (modal confirmation) não estava funcionando. Acrescentamos endpoint para que seja feita a transição para a terceira modal (modal acceptance).